### PR TITLE
Add zelect0r Android Modules Repository

### DIFF
--- a/meta/repositories.json
+++ b/meta/repositories.json
@@ -220,5 +220,23 @@
       }
     ],
     "url": "https://juliazero.github.io/mrbj/"
-  }
+  },
+  {
+  "name": "zelect0rs Android Modules Repository",
+  "maintainers": [],
+  "members": [
+    {
+      "avatar": "https://github.com/zelect0r.png",
+      "name": "zelect0r",
+      "title": "Owner",
+      "links": [
+        {
+          "icon": "github",
+          "link": "https://github.com/zelect0r"
+        }
+      ]
+    }
+  ],
+  "url": "https://zelect0r.github.io/zamr/"
+}
 ]


### PR DESCRIPTION
Add zelect0r's Android Modules Repository to the MMRL repository list.

Repository:
https://github.com/zelect0r/zamr

MMRL base URL:
https://zelect0r.github.io/zamr/

The repository provides Android root modules for Magisk, KernelSU, APatch and MMRL.